### PR TITLE
Add author social media icons to byline

### DIFF
--- a/src/partials/entry-author.php
+++ b/src/partials/entry-author.php
@@ -30,6 +30,18 @@ $author_option = ttfmake_sanitize_choice( get_theme_mod( $author_key, ttfmake_ge
 				esc_html( get_the_author_meta( 'display_name' ) )
 			)
 		);
+		$twitter = get_the_author_meta('twitter');
+		$fb = get_the_author_meta('facebook');
+		$gplus = get_the_author_meta('googleplus');
+		if (!empty($twitter)){
+			echo '<a href="http://twitter.com/' . $twitter . '" class="author-social"><i class="fa fa-twitter"></i></a>';
+			}
+		if (!empty($fb)){
+			echo '<a href="http://' . $fb . '" class="author-social"><i class="fa fa-facebook"></i></a>';
+			}
+		if (!empty($gplus)){
+			echo '<a href="http://' . $gplus . '" class="author-social"><i class="fa fa-google-plus"></i></a>';
+			}
 		?>
 	</div>
 	<?php if ( is_singular() && $author_bio = get_the_author_meta( 'description' ) ) : ?>


### PR DESCRIPTION
Just a suggestion. Naturally, this could be tied into a setting in the Customizr as well, but as is, it only shows on the author byline if the author adds this info into their profile.

Optionally, you could add these styles as well in order to have the actual social media colors appear on hover.

a.author-social {
margin: 0 0 0 1em;
}

.author-social:hover .fa-facebook {color: #3b5998;}
.author-social:hover .fa-twitter {color: #00aced;}
.author-social:hover .fa-google-plus {color: #dd4b39;}