### PR TITLE
Remove onclick event

### DIFF
--- a/src/inc/builder/sections/front-end-templates/gallery.php
+++ b/src/inc/builder/sections/front-end-templates/gallery.php
@@ -18,7 +18,7 @@ $aspect   = ( isset( $ttfmake_section_data[ 'aspect' ] ) ) ? esc_attr( $ttfmake_
 	<?php endif; ?>
 	<div class="builder-section-content">
 		<?php if ( ! empty( $gallery ) ) : $i = 0; foreach ( $gallery as $item ) :
-			$onclick = ' onclick="return false;"';
+			$onclick = '';
 			if ( '' !== $item['link'] ) :
 				$onclick = ' onclick="window.location.href = \'' . esc_js( esc_url( $item['link'] ) ) . '\';"';
 			endif;


### PR DESCRIPTION
If the description has HTML in it with a link, the links don't work.