### PR TITLE
Use canonical protocol when searching for logo post by attachment URL.

### DIFF
--- a/src/inc/customizer/logo.php
+++ b/src/inc/customizer/logo.php
@@ -85,6 +85,14 @@ class TTFMAKE_Logo {
 			return false;
 		}
 
+		// Literal URL matches should always match canonical scheme for the site.
+		$upload_dir_paths = wp_upload_dir();
+		if ( set_url_scheme( $upload_dir_paths['baseurl'], 'https' ) === $upload_dir_paths['baseurl'] ) {
+			$url = set_url_scheme( $url, 'https' );
+		} else {
+			$url = set_url_scheme( $url, 'http' );
+		}
+
 		global $wpdb;
 		$attachment_id = 0;
 
@@ -110,7 +118,6 @@ class TTFMAKE_Logo {
 		}
 
 		// Then try this
-		$upload_dir_paths = wp_upload_dir();
 		if ( false !== strpos( $url, $upload_dir_paths['baseurl'] ) ) {
 			// If this is the URL of an auto-generated thumbnail, get the URL of the original image
 			$url = preg_replace( '/-\d+x\d+(?=\.(jpg|jpeg|png|gif)$)/i', '', $url );


### PR DESCRIPTION
The guid of attachment post items will have a protocol (http or https) that
matches the canonical protocol of the site, as returned by `wp_upload_dir()`.
In certain configurations, such as `FORCE_SSL_ADMIN`, the canonical URL may
be `http` while the current image URL is `https`. This can result in misses
when `TTFMAKE_Logo::get_attachment_id_from_url()` attempts to match a URL
against guid column.

Note that this only happens when the `attachment_url_to_postid()` check fails.
(`attachment_url_to_postid()` does a similar protocol-match before running its
query.) I haven't looked deeply into why it's failing in my specific case, but
it's possible that it's related to the fact that I'm running Multisite and
running some customizations related to ms-blogs.php file serving.